### PR TITLE
Preact and optimisation

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -12,12 +12,12 @@ module.exports = env => {
     entry: {
       app: './src/client/index.js',
       vendor: [
-        'react',
-        'react-dom',
+        'preact',
+        'preact-tap-event-plugin',
         'react-router-dom',
         'prop-types',
         'material-ui',
-        'react-tap-event-plugin',
+        'moment',
         'react-chartjs-2',
         'chart.js'
       ]
@@ -29,6 +29,8 @@ module.exports = env => {
     },
     resolve: {
       alias: {
+        'react': 'preact-compat',
+        'react-dom': 'preact-compat',
         'views': resolve(__dirname, '../src/client/views')
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "lint": "eslint .",
     "lint-auto": "eslint --fix .",
     "test": "mocha",
-    "start": "NODE_ENV=production node src/server/index.js | tee -a logs/transactions.log",
-    "build-client": "webpack --env.production --config config/webpack",
+    "start": "node src/server/index.js",
+    "build": "webpack --env.production --config config/webpack",
     "watch-client": "webpack-dashboard -- webpack-dev-server --config config/webpack",
     "watch-server": "nodemon --watch src/server src/server/index.js"
   },
@@ -34,12 +34,12 @@
     "moment": "^2.18.1",
     "moment-timezone": "^0.5.13",
     "mongoose": "^4.9.6",
+    "preact": "^8.1.0",
+    "preact-compat": "^3.16.0",
+    "preact-tap-event-plugin": "^0.1.2",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4",
     "react-chartjs-2": "^2.0.5",
-    "react-dom": "^15.5.4",
     "react-router-dom": "^4.1.1",
-    "react-tap-event-plugin": "^2.0.1",
     "striptags": "^3.0.1"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Available on [npm][]
 git clone https://github.com/omarchehab98/eun
 npm install
 npm test
-npm run build-client
+npm run build
 npm start
 ```
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,7 +4,7 @@ import './index.scss'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import Snackbar from 'material-ui/Snackbar'
 
-import injectTapEventPlugin from 'react-tap-event-plugin'
+import injectTapEventPlugin from 'preact-tap-event-plugin'
 // Needed for onTouchTap
 // http://stackoverflow.com/a/34015469/988941
 injectTapEventPlugin()

--- a/src/client/views/helpers/network.js
+++ b/src/client/views/helpers/network.js
@@ -1,6 +1,6 @@
 const esc = window.encodeURIComponent
 
-const url = 'http://localhost:3001/v1'
+const url = 'http://localhost:8080/v1'
 const endpoints = {
   generateToken: () => `${url}/authentication/generateToken`,
   validateToken: () => `${url}/authentication/validateToken`,

--- a/src/client/views/pages/ExpensesPage/ExpensesPage.js
+++ b/src/client/views/pages/ExpensesPage/ExpensesPage.js
@@ -10,7 +10,7 @@ import {
   Doughnut as DoughnutChart
 } from 'react-chartjs-2'
 import moment from 'moment'
-import { map } from 'lodash'
+import map from 'lodash/map'
 
 import Card from 'material-ui/Card'
 import Chip from 'material-ui/Chip'

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -28,12 +28,3 @@ API(credentials.api, {
   authentication
 })
 console.log('API: localhost:' + credentials.api.port)
-
-if (process.env.NODE_ENV === 'production') {
-  const express = require('express')
-  const webserver = express()
-  const port = 3000
-  webserver.use(express.static('dist'))
-  webserver.listen(port)
-  console.log('Webserver: localhost:' + port)
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,6 +3243,12 @@ imap@^0.8.19:
     readable-stream "1.1.x"
     utf7 ">=1.0.2"
 
+immutability-helper@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.2.2.tgz#e7e9da728b3de2fad34a216f4157b326dbccc892"
+  dependencies:
+    invariant "^2.2.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -3933,7 +3939,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5078,6 +5084,34 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+preact-compat@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.16.0.tgz#cf2bc1b2f8fca14900d68094f9e10b8b329cc41e"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-render-to-string@^3.6.0:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.6.3.tgz#481d0d5bdac9192d3347557437d5cd00aa312043"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-tap-event-plugin@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/preact-tap-event-plugin/-/preact-tap-event-plugin-0.1.2.tgz#3545b22e9e52d7ca8836df5926d50a73bdbe070a"
+
+preact-transition-group@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
+
+preact@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.1.0.tgz#f035b808eebb74e46d56246b02ca0f190b6d6574"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5101,6 +5135,10 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -5123,7 +5161,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5247,15 +5285,6 @@ react-chartjs-2@^2.0.5:
   dependencies:
     lodash.isequal "^4.4.0"
 
-react-dom@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "~15.5.7"
-
 react-event-listener@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.4.5.tgz#e3e895a0970cf14ee8f890113af68197abf3d0b1"
@@ -5291,15 +5320,6 @@ react-tap-event-plugin@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
   dependencies:
     fbjs "^0.8.6"
-
-react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.7"
 
 read-all-stream@^3.0.0:
   version "3.1.0"
@@ -5967,6 +5987,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+standalone-react-addons-pure-render-mixin@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"


### PR DESCRIPTION
* Rename script `build-client` to `build`
* Use `preact` and `preact-compat` instead of `react`.
* Remove unused vendor.
    * Reduce `lodash` to `lodash/map`.
* Remove built in production webserver.